### PR TITLE
fix(ci): CI 只在 push main 觸發 + 加並發控制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,19 @@ name: CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
+  # Triggers the workflow on push to the "main" branch
+  # 注意：刻意不在 pull_request 觸發——這個 job 會把 ncu 升級結果推回 main，
+  # 在 PR 的 detached HEAD 上推 main 一定會失敗（fetch first），且 PR 階段沒有測試需求。
   push:
-    branches: [ "main" ]
-  pull_request:
     branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+# 同一時間只跑一個，避免兩個 run 同時推 main 造成 non-fast-forward 競態
+concurrency:
+  group: ci-main
+  cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -24,10 +29,8 @@ jobs:
     - name: ncu-upgrade
       run: |
         npm i -g npm-check-updates
-        ncu -u 
+        ncu -u
     - name: Commit & Push changes
       uses: actions-js/push@v1.3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-
-


### PR DESCRIPTION
## 問題
`ci.yml` 在 `pull_request` 事件也會跑，會在 PR 的 detached HEAD 上用 `actions-js/push` 嘗試把 `ncu -u` 的結果推回 `main` → 必然 `! [rejected] ... (fetch first)`。AI 週報自動化每開一個 PR 就觸發一次失敗的 CI。

## 修正
- 移除 `pull_request` 觸發（此 job 無測試、只做 ncu 升級 + 推 main，PR 階段不該推 main）
- 加 `concurrency: ci-main / cancel-in-progress`，避免兩個 run 同時推 main 的競態

## 注意
這張 PR 本身仍會觸發**舊版** CI（pull_request）一次而顯示失敗——屬預期，merge 後即生效、之後 PR 不再觸發。

🤖 Generated with [Claude Code](https://claude.com/claude-code)